### PR TITLE
No longer use Geocode for UPS Timestamp

### DIFF
--- a/carriers/ups.js
+++ b/carriers/ups.js
@@ -189,7 +189,9 @@ function UPS(options) {
                         address = addresses.find(a => a && a.location === activity.location);
                     }
 
-                    let timezone = 'UTC';
+                    let timezone = activity.GMTTime
+                        ? 'UTC'
+                        : 'America/New_York';
 
                     if (address && address.timezone) {
                         timezone = address.timezone;

--- a/carriers/ups.js
+++ b/carriers/ups.js
@@ -91,7 +91,8 @@ function UPS(options) {
                     InquiryNumber: trackingNumber,
                     Request: {
                         RequestAction: 'Track',
-                        RequestOption: 'activity'
+                        RequestOption: 'activity',
+                        SubVersion: '1907',
                     }
                 }
             },
@@ -162,6 +163,7 @@ function UPS(options) {
                 if (!location) {
                     callback();
                 } else {
+                    /*
                     geography.parseLocation(location, options, function(err, address) {
                         if (err || !address) {
                             return callback(err);
@@ -171,6 +173,8 @@ function UPS(options) {
 
                         callback(null, address);
                     });
+                     */
+                    callback(null, location);
                 }
             }, function(err, addresses) {
                 if (err) {
@@ -184,15 +188,15 @@ function UPS(options) {
                         address = addresses.find(a => a && a.location === activity.location);
                     }
 
-                    let timezone = 'America/New_York';
+                    let timezone = 'UTC';
 
-                    if (address && address.timezone) {
-                        timezone = address.timezone;
-                    }
+                    //if (address && address.timezone) {
+                        //timezone = address.timezone;
+                    //}
 
                     const event = {
                         address: activity.address,
-                        date: moment.tz(`${activity.Date} ${activity.Time}`, 'YYYYMMDD HHmmss', timezone).toDate(),
+                        date: moment.tz(`${activity.GMTDate} ${activity.GMTTime}`, 'YYYYMMDD HHmmss', timezone).toDate(),
                         description: activity.Description || (activity.Status && activity.Status.Description) || (activity.Status && activity.Status.StatusType && activity.Status.StatusType.Description)
                     };
 


### PR DESCRIPTION
UPS has a request flag that allows the returning of GMT time information
which can be used directly without the need for geocode tools to help
with the timezone conversion logic.

This commit only commented out the existing code to use the GMT time
instead of geocode logic. It is feasible to think that some more code may
also be obsolete as a result and more cleanups can take place.