### PR TITLE
Allow an option to include the status information for UPS

### DIFF
--- a/carriers/dhl.js
+++ b/carriers/dhl.js
@@ -143,6 +143,10 @@ function DHL() {
             // Reverse results again to get events in order Most Recent - Least Recent
             results.events.reverse();
 
+            if (_options.raw === true) {
+                results.raw = body;
+            }
+
             if (!results.shippedAt && results.deliveredAt) {
                 results.shippedAt = results.deliveredAt;
             }

--- a/carriers/fedEx.js
+++ b/carriers/fedEx.js
@@ -163,6 +163,10 @@ function FedEx(options) {
             // Add url to carrier tracking page
             results.url = `https://www.fedex.com/apps/fedextrack/?tracknumbers=${encodeURIComponent(trackingNumber)}`;
 
+            if (_options.raw === true) {
+                results.raw = trackReply;
+            }
+
             if (!results.shippedAt && results.deliveredAt) {
                 results.shippedAt = results.deliveredAt;
             }

--- a/carriers/pitneyBowes.js
+++ b/carriers/pitneyBowes.js
@@ -145,6 +145,10 @@ function PitneyBowes(options) {
                     results.url = `https://tracking.pb.com/${trackingNumber.substring(0, 20)}`;
                 }
 
+                if (_options.raw === true) {
+                    results.raw = data;
+                }
+
                 if (!results.shippedAt && results.deliveredAt) {
                     results.shippedAt = results.deliveredAt;
                 }

--- a/carriers/ups.js
+++ b/carriers/ups.js
@@ -198,13 +198,6 @@ function UPS(options) {
                         return;
                     }
 
-                    if (_options.status === true) {
-                        event.status = activity.Status;
-                        if (!results.status) {
-                            results.status = activity.Status;
-                        }
-                    }
-
                     if (activity.Status.Type == "D") {
                         results.deliveredAt = event.date;
                     }
@@ -228,6 +221,10 @@ function UPS(options) {
 
                 // Add URL to carrier tracking page
                 results.url = `https://www.ups.com/track?tracknum=${encodeURIComponent(trackingNumber)}`;
+
+                if (_options.raw === true) {
+                    results.raw = body;
+                }
 
                 if (!results.shippedAt && results.deliveredAt) {
                     results.shippedAt = results.deliveredAt;

--- a/carriers/ups.js
+++ b/carriers/ups.js
@@ -204,6 +204,13 @@ function UPS(options) {
                         return;
                     }
 
+                    if (_options.status === true) {
+                        event.status = activity.Status;
+                        if (!results.status) {
+                            results.status = activity.Status;
+                        }
+                    }
+
                     if (DELIVERED_DESCRIPTIONS.includes(event.description.toUpperCase())) {
                         results.deliveredAt = event.date;
                     }

--- a/carriers/ups.js
+++ b/carriers/ups.js
@@ -6,12 +6,6 @@ const xml2json = require('fast-xml-parser');
 const geography = require('../util/geography');
 const USPS = require('./usps');
 
-// These are all of the status descriptions related to delivery provided by UPS.
-const DELIVERED_DESCRIPTIONS = ['DELIVERED', 'DELIVERED BY LOCAL POST OFFICE', 'DELIVERED TO UPS ACCESS POINT AWAITING CUSTOMER PICKUP'];
-
-// These are all of the status descriptions related to shipping provided by UPS.
-const SHIPPED_DESCRIPTIONS = ['ARRIVAL SCAN', 'DELIVERED', 'DEPARTURE SCAN', 'DESTINATION SCAN', 'ORIGIN SCAN', 'OUT FOR DELIVERY', 'OUT FOR DELIVERY TODAY', 'PACKAGE DEPARTED UPS MAIL INNOVATIONS FACILITY ENROUTE TO USPS FOR INDUCTION', 'PACKAGE PROCESSED BY UPS MAIL INNOVATIONS ORIGIN FACILITY', 'PACKAGE RECEIVED FOR PROCESSING BY UPS MAIL INNOVATIONS', 'PACKAGE RECEIVED FOR SORT BY DESTINATION UPS MAIL INNOVATIONS FACILITY', 'PACKAGE TRANSFERRED TO DESTINATION UPS MAIL INNOVATIONS FACILITY', 'PACKAGE OUT FOR POST OFFICE DELIVERY', 'PACKAGE SORTED BY POST OFFICE', 'RECEIVED BY THE POST OFFICE', 'SHIPMENT ACCEPTANCE AT POST OFFICE', 'YOUR PACKAGE IS IN TRANSIT TO THE UPS FACILITY.', 'LOADED ON DELIVERY VEHICLE'];
-
 function getActivities(package) {
     var activitiesList = package.Activity;
 
@@ -209,20 +203,13 @@ function UPS(options) {
                         if (!results.status) {
                             results.status = activity.Status;
                         }
+                    }
 
-                        if (activity.Status.Type == "D") {
-                            results.deliveredAt = event.date;
-                        }
-                        if (activity.Status.Type == "I") {
-                            results.shippedAt = event.date;
-                        }
-                    } else {
-                        if (DELIVERED_DESCRIPTIONS.includes(event.description.toUpperCase())) {
-                            results.deliveredAt = event.date;
-                        }
-                        if (SHIPPED_DESCRIPTIONS.includes(event.description.toUpperCase())) {
-                            results.shippedAt = event.date;
-                        }
+                    if (activity.Status.Type == "D") {
+                        results.deliveredAt = event.date;
+                    }
+                    if (activity.Status.Type == "I") {
+                        results.shippedAt = event.date;
                     }
 
                     // Use the city and state from the parsed address (for scenarios where the city includes the state like "New York, NY")

--- a/carriers/ups.js
+++ b/carriers/ups.js
@@ -209,14 +209,20 @@ function UPS(options) {
                         if (!results.status) {
                             results.status = activity.Status;
                         }
-                    }
 
-                    if (DELIVERED_DESCRIPTIONS.includes(event.description.toUpperCase())) {
-                        results.deliveredAt = event.date;
-                    }
-
-                    if (SHIPPED_DESCRIPTIONS.includes(event.description.toUpperCase())) {
-                        results.shippedAt = event.date;
+                        if (activity.Status.Type == "D") {
+                            results.deliveredAt = event.date;
+                        }
+                        if (activity.Status.Type == "I") {
+                            results.shippedAt = event.date;
+                        }
+                    } else {
+                        if (DELIVERED_DESCRIPTIONS.includes(event.description.toUpperCase())) {
+                            results.deliveredAt = event.date;
+                        }
+                        if (SHIPPED_DESCRIPTIONS.includes(event.description.toUpperCase())) {
+                            results.shippedAt = event.date;
+                        }
                     }
 
                     // Use the city and state from the parsed address (for scenarios where the city includes the state like "New York, NY")

--- a/carriers/usps.js
+++ b/carriers/usps.js
@@ -195,6 +195,10 @@ function USPS(options) {
                     // Add url to carrier tracking page
                     results.url = `https://tools.usps.com/go/TrackConfirmAction?qtc_tLabels1=${encodeURIComponent(trackingNumber)}`;
 
+                    if (_options.raw === true) {
+                        results.raw = data;
+                    }
+
                     if (!results.shippedAt && results.deliveredAt) {
                         results.shippedAt = results.deliveredAt;
                     }

--- a/index.js
+++ b/index.js
@@ -89,9 +89,9 @@ function Bloodhound(options) {
         trackingNumber = trackingNumber.toUpperCase();
 
         if (options.carrier === 'dhl') {
-            dhl.track(trackingNumber, callback);
+            dhl.track(trackingNumber, options, callback);
         } else if (options.carrier === 'fedex') {
-            fedEx.track(trackingNumber, callback);
+            fedEx.track(trackingNumber, options, callback);
         } else if (options.carrier === 'newgistics') {
             pitneyBowes.track(trackingNumber, options, callback);
         } else if (options.carrier === 'pitney bowes') {
@@ -99,7 +99,7 @@ function Bloodhound(options) {
         } else if (options.carrier === 'ups'){
             ups.track(trackingNumber, options, callback);
         } else if (options.carrier === 'usps') {
-            usps.track(trackingNumber, callback);
+            usps.track(trackingNumber, options, callback);
         } else {
             return callback(new Error(`Carrier ${options.carrier} is not supported.`));
         }

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ function Bloodhound(options) {
         } else if (options.carrier === 'pitney bowes') {
             pitneyBowes.track(trackingNumber, options, callback);
         } else if (options.carrier === 'ups'){
-            ups.track(trackingNumber, callback);
+            ups.track(trackingNumber, options, callback);
         } else if (options.carrier === 'usps') {
             usps.track(trackingNumber, callback);
         } else {


### PR DESCRIPTION
As a user, I'd like to process the status information found on the activity of the UPS information.  This is more reliable than relying on the human readable description; which may change or be altered.  The status/type is a stable indicators of the state of the package.

I've updated the shippedAt/deliveredAt values to use status/type _if_ the option to return status is set by the user; otherwise defaulting back to the text processing.  The status is already included with the current request, it may be simpler to always use the status/type; since that wouldn't require updating the string values in DELIVERED_DESCRIPTIONS and SHIPPED_DESCRIPTIONS.

Injecting the last available status in 'result' for ease of processing.

 On branch ups-status
 Changes to be committed:
        modified:   carriers/ups.js
        modified:   index.js