### PR TITLE
Update USPS endpoint to use https

### DIFF
--- a/carriers/usps.js
+++ b/carriers/usps.js
@@ -68,7 +68,7 @@ function USPS(options) {
         const xml = `<TrackFieldRequest USERID="${options.userId}"><Revision>1</Revision><ClientIp>${options.clientIp || '127.0.0.1'}</ClientIp><SourceId>${options.sourceId || '@mediocre/bloodhound (+https://github.com/mediocre/bloodhound)'}</SourceId><TrackID ID="${trackingNumber}"/></TrackFieldRequest>`;
 
         const req = {
-            baseUrl: options.baseUrl || 'http://production.shippingapis.com',
+            baseUrl: options.baseUrl || 'https://production.shippingapis.com',
             method: 'GET',
             timeout: 5000,
             url: `/ShippingAPI.dll?API=TrackV2&XML=${encodeURIComponent(xml)}`


### PR DESCRIPTION
Based on USPS's release notes, they're retiring their insecure http endpoints.  I've updated the address to use http**s**.

See Page 6, Section 2.6.1.
https://www.usps.com/business/web-tools-apis/2021-web-tools-release-notes.pdf