### PR TITLE
Match status on startsWith rather than exact match

### DIFF
--- a/carriers/dhl.js
+++ b/carriers/dhl.js
@@ -167,11 +167,11 @@ function DHL(options) {
                             _event.details = event.remark;
                         }
 
-                        if (!results.deliveredAt && _event.description && DELIVERED_TRACKING_DESCRIPTIONS.includes(_event.description.toUpperCase())) {
+                        if (!results.deliveredAt && _event.description && DELIVERED_TRACKING_DESCRIPTIONS.find(desc => _event.description.toUpperCase().startsWith(desc))) {
                             results.deliveredAt = _event.date;
                         }
 
-                        if (!results.shippedAt && _event.description && SHIPPED_TRACKING_DESCRIPTIONS.includes(_event.description.toUpperCase())) {
+                        if (!results.shippedAt && _event.description && SHIPPED_TRACKING_DESCRIPTIONS.find(desc => _event.description.toUpperCase().startsWith(desc))) {
                             results.shippedAt = _event.date;
                         }
 

--- a/carriers/dhlEcommerceSolutions.js
+++ b/carriers/dhlEcommerceSolutions.js
@@ -172,11 +172,11 @@ function DhlEcommerceSolutions(options) {
                     _event.details = event.secondaryEventDescription;
                 }
 
-                if (!results.deliveredAt && _event.description && DELIVERED_TRACKING_DESCRIPTIONS.includes(_event.description.toUpperCase())) {
+                if (!results.deliveredAt && _event.description && DELIVERED_TRACKING_DESCRIPTIONS.find(desc => _event.description.toUpperCase().startsWith(desc))) {
                     results.deliveredAt = _event.date;
                 }
 
-                if (!results.shippedAt && _event.description && SHIPPED_TRACKING_DESCRIPTIONS.includes(_event.description.toUpperCase())) {
+                if (!results.shippedAt && _event.description && SHIPPED_TRACKING_DESCRIPTIONS.find(desc => _event.description.toUpperCase().startsWith(desc))) {
                     results.shippedAt = _event.date;
                 }
 


### PR DESCRIPTION
We're seeing DHL shipments go onto the late shipments report, but they have what looks like a movement-worthy status.

From what I can tell, DHL updated their status to include more information, but we are checking a list of values for equality rather than startsWith.

I updated the status comparisons to use startsWith rather than equality to see if we can get these packages marked as `shipped`.