### PR TITLE
Add Amazon tracking number support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.1.0] - 2025-06-27
+### Added
+- Added Amazon Shipping tracking support for TBA/TBM/TBC tracking numbers
+- Comprehensive event code mapping for Amazon tracking events including delivery attempts, exceptions, returns, and holds
 
 ## [2.0.0] - 2024-08-30
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.1.0] - 2025-06-27
 ### Added
-- Added Amazon Shipping tracking support for TBA/TBM/TBC tracking numbers
-- Comprehensive event code mapping for Amazon tracking events including delivery attempts, exceptions, returns, and holds
+- Added Amazon Shipping tracking support for TBA/TBM/TBC tracking numbers.
 
 ## [2.0.0] - 2024-08-30
 ### Changed

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ bloodhound.track('tracking number', 'FedEx', function(err, data) {
 
 **amazon**
 
-The Amazon carrier does not require any configuration. It works with Amazon tracking numbers (TBA/TBM/TBC format).
+The Amazon carrier does not require any configuration. It works with Amazon Shipping tracking numbers (TBA/TBM/TBC format).
 
 **dhl**
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ bloodhound.track('tracking number', 'FedEx', function(err, data) {
 
 **amazon**
 
-The Amazon carrier does not require any configuration. It works with Amazon Shipping tracking numbers (TBA/TBM/TBC format).
+The Amazon Shipping carrier does not require any configuration. It works with Amazon Shipping tracking numbers (TBA/TBM/TBC format).
 
 **dhl**
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ![Elvis Presley & Bloodhound - Photo - 1964](https://res.cloudinary.com/mediocre/image/upload/v1562632498/rpkudq0xpyysdty9nkzk.jpg)
 
-Bloodhound is a Node.js package that allows you to retrieve tracking data from shipping carriers (DHL, FedEx, UPS, USPS) in a common format.
+Bloodhound is a Node.js package that allows you to retrieve tracking data from shipping carriers (Amazon, DHL, FedEx, UPS, USPS) in a common format.
 
 This module was inspired by the excellent `shipit` module. We built Bloodhound to provide better support for parsing of timestamps (read more below).
 
@@ -33,6 +33,7 @@ Bloodhound can guess the carrier given a tracking number explicity through the `
 Bloodhound also examines each of the activity/movement/scan events for "shipped" and "delievered" event types (beyond simple electronic events like "shipping label created" or "manifest file sent"). When a matching event type is encountered Bloodhound returns a `shippedAt` and `deliveredAt` date.
 
 ## Supported Carriers
+- Amazon
 - DHL
 - FedEx
 - UPS
@@ -100,7 +101,13 @@ bloodhound.track('tracking number', 'FedEx', function(err, data) {
     console.log(data);
 });
 ```
+
+**amazon**
+
+The Amazon carrier does not require any configuration. It works with Amazon tracking numbers (TBA/TBM/TBC format).
+
 **dhl**
+
 The DHL API requires an API key: https://developer.dhl.com.
 
 *geocoder**

--- a/carriers/amazon.js
+++ b/carriers/amazon.js
@@ -68,7 +68,7 @@ function Amazon() {
         trackingNumber = trackingNumber.replace(/\s/g, '');
         trackingNumber = trackingNumber.toUpperCase();
 
-        // Amazon tracking numbers: TB + (A|B|C) + 12 digits
+        // Amazon Shipping tracking numbers: TB + (A|B|C) + 12 digits
         return /^TB[A-CM][0-9]{12}$/.test(trackingNumber);
     };
 

--- a/carriers/amazon.js
+++ b/carriers/amazon.js
@@ -153,7 +153,7 @@ function Amazon() {
             }
 
             // Sort events by date (oldest first)
-            results.events.sort((a, b) => new Date(a.date) - new Date(b.date));
+            results.events.sort((a, b) => a.date - b.date);
 
             return callback(null, results);
         } catch (err) {

--- a/carriers/amazon.js
+++ b/carriers/amazon.js
@@ -1,0 +1,165 @@
+const createError = require('http-errors');
+
+// These event codes indicate the shipment was delivered
+const DELIVERED_EVENT_CODES = ['Delivered'];
+
+// These event codes indicate the shipment is in the carrier's network
+const SHIPPED_EVENT_CODES = ['PickupDone', 'Received', 'InTransit', 'Departed', 'ArrivedAtSortCenter'];
+
+function Amazon() {
+    // Helper function to convert Amazon event codes to readable descriptions
+    const parseEventDescription = (eventCode, statusSummary) => {
+        const eventMap = {
+            'ArrivedAtDeliveryCenter': 'Arrived at delivery center',
+            'ArrivedAtSortCenter': 'Arrived at sort center',
+            'AttemptFail': 'Delivery attempt failed',
+            'CreationConfirmed': 'Shipping label created',
+            'Delivered': 'Package delivered',
+            'DeliveryAttempted': 'Delivery attempted',
+            'Departed': 'Departed facility',
+            'Exception': 'Exception occurred',
+            'Held': 'Package held',
+            'InTransit': 'Package in transit',
+            'InTransitToCustomer': 'In transit to customer',
+            'LabelCreated': 'Shipping label created',
+            'OutForDelivery': 'Out for delivery',
+            'OutForReturn': 'Out for return',
+            'PickupDone': 'Package picked up',
+            'Received': 'Package received at facility',
+            'Refused': 'Package refused',
+            'Returned': 'Package returned',
+            'ReturnReceived': 'Return received',
+            'Sorted': 'Package sorted',
+            'Transferred': 'Package transferred',
+            'Undeliverable': 'Package undeliverable'
+        };
+
+        // Use status summary if available, otherwise fall back to event code mapping
+        if (statusSummary && statusSummary.localisedStringId) {
+            // Convert localized string IDs to readable text
+            const summaryMap = {
+                'swa_rex_arrived_at_sort_center': 'Arrived at sort center',
+                'swa_rex_delivered': 'Package delivered',
+                'swa_rex_detail_arrived_at_delivery_Center': 'Arrived at delivery center',
+                'swa_rex_detail_attempted': 'Delivery attempted',
+                'swa_rex_detail_creation_confirmed': 'Shipping label created',
+                'swa_rex_detail_delivered': 'Package delivered',
+                'swa_rex_detail_departed': 'Departed facility',
+                'swa_rex_detail_exception': 'Exception occurred',
+                'swa_rex_detail_held': 'Package held',
+                'swa_rex_detail_in_transit': 'Package in transit',
+                'swa_rex_detail_pickedUp': 'Package picked up',
+                'swa_rex_detail_refused': 'Package refused',
+                'swa_rex_detail_returned': 'Package returned',
+                'swa_rex_detail_undeliverable': 'Package undeliverable',
+                'swa_rex_intransit': 'Package in transit',
+                'swa_rex_ofd': 'Out for delivery',
+                'swa_rex_shipping_label_created': 'Shipping label created'
+            };
+
+            return summaryMap[statusSummary.localisedStringId] || statusSummary.localisedStringId;
+        }
+
+        return eventMap[eventCode] || eventCode;
+    };
+
+    this.isTrackingNumberValid = trackingNumber => {
+        // Remove whitespace
+        trackingNumber = trackingNumber.replace(/\s/g, '');
+        trackingNumber = trackingNumber.toUpperCase();
+
+        // Amazon tracking numbers: TB + (A|B|C) + 12 digits
+        return /^TB[A-CM][0-9]{12}$/.test(trackingNumber);
+    };
+
+    this.track = async (trackingNumber, _options, callback) => {
+        // Options are optional
+        if (typeof _options === 'function') {
+            callback = _options;
+            _options = {};
+        }
+
+        if (!_options.minDate) {
+            _options.minDate = new Date(0);
+        }
+
+        // Clean tracking number
+        trackingNumber = trackingNumber.replace(/\s/g, '').toUpperCase();
+
+        try {
+            const res = await fetch(`https://track.amazon.com/api/tracker/${trackingNumber}`, {
+                signal: AbortSignal.timeout(30000)
+            });
+
+            if (!res.ok) {
+                throw createError(res.status);
+            }
+
+            const json = await res.json();
+
+            const results = {
+                carrier: 'Amazon',
+                events: [],
+                raw: json,
+                url: `https://track.amazon.com/tracking/${trackingNumber}`
+            };
+
+            if (!json) {
+                // No data returned, return empty results
+                return callback(null, results);
+            }
+
+            // Parse event history for detailed tracking events
+            if (json.eventHistory) {
+                const eventHistory = typeof json.eventHistory === 'string' ? JSON.parse(json.eventHistory) : json.eventHistory;
+
+                if (eventHistory.eventHistory && Array.isArray(eventHistory.eventHistory)) {
+                    for (let i = 0; i < eventHistory.eventHistory.length; i++) {
+                        const event = eventHistory.eventHistory[i];
+
+                        const trackingEvent = {
+                            address: {},
+                            date: new Date(event.eventTime),
+                            description: parseEventDescription(event.eventCode, event.statusSummary),
+                            details: event.eventCode
+                        };
+
+                        // Add location information if available
+                        if (event.location) {
+                            trackingEvent.address = {
+                                city: event.location.city,
+                                state: event.location.stateProvince,
+                                country: event.location.countryCode,
+                                zip: event.location.postalCode
+                            };
+                        }
+
+                        // Set shipping date for events that indicate movement in carrier network
+                        if (SHIPPED_EVENT_CODES.includes(event.eventCode) && !results.shippedAt) {
+                            results.shippedAt = new Date(event.eventTime);
+                        }
+
+                        // Set delivery date for delivery events
+                        if (DELIVERED_EVENT_CODES.includes(event.eventCode)) {
+                            results.deliveredAt = new Date(event.eventTime);
+                        }
+
+                        // Filter events after minDate
+                        if (trackingEvent.date >= _options.minDate) {
+                            results.events.push(trackingEvent);
+                        }
+                    }
+                }
+            }
+
+            // Sort events by date (oldest first)
+            results.events.sort((a, b) => new Date(a.date) - new Date(b.date));
+
+            return callback(null, results);
+        } catch (err) {
+            return callback(err);
+        }
+    };
+}
+
+module.exports = Amazon;

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const NodeGeocoder = require('node-geocoder');
+const Amazon = require('./carriers/amazon');
 const PitneyBowes = require('./carriers/pitneyBowes');
 const UPS = require('./carriers/ups');
 const FedEx = require('./carriers/fedEx');
@@ -60,6 +61,7 @@ function Bloodhound(options) {
         options.ups.usps = options.usps;
     }
 
+    const amazon = new Amazon(options && options.amazon);
     const dhl = new DHL(options && options.dhl);
     const fedEx = new FedEx(options && options.fedEx);
     const pitneyBowes = new PitneyBowes(options && options.pitneyBowes);
@@ -67,7 +69,9 @@ function Bloodhound(options) {
     const usps = new USPS(options && options.usps);
 
     this.guessCarrier = function(trackingNumber) {
-        if (dhl.isTrackingNumberValid(trackingNumber)) {
+        if (amazon.isTrackingNumberValid(trackingNumber)) {
+            return 'Amazon';
+        } else if (dhl.isTrackingNumberValid(trackingNumber)) {
             return 'DHL';
         } else if (fedEx.isTrackingNumberValid(trackingNumber)) {
             return 'FedEx';
@@ -112,7 +116,9 @@ function Bloodhound(options) {
         trackingNumber = trackingNumber.replace(/\s/g, '');
         trackingNumber = trackingNumber.toUpperCase();
 
-        if (options.carrier === 'dhl') {
+        if (options.carrier === 'amazon') {
+            amazon.track(trackingNumber, options, callback);
+        } else if (options.carrier === 'dhl') {
             dhl.track(trackingNumber, options, callback);
         } else if (options.carrier === 'fedex') {
             fedEx.track(trackingNumber, options, callback);

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "description": "Bloodhound is a Node.js package that allows you to retrieve tracking data from shipping carriers (DHL, FedEx, UPS, USPS) in a common format.",
+    "description": "Bloodhound is a Node.js package that allows you to retrieve tracking data from shipping carriers (Amazon, DHL, FedEx, UPS, USPS) in a common format.",
     "dependencies": {
         "async": "~3.2.0",
         "dhl-ecommerce-solutions": "~0.3.0",
@@ -23,6 +23,7 @@
     },
     "homepage": "https://github.com/mediocre/bloodhound",
     "keywords": [
+        "amazon",
         "dhl",
         "fedex",
         "logistics",
@@ -44,5 +45,5 @@
         "type": "git",
         "url": "https://github.com/mediocre/bloodhound.git"
     },
-    "version": "2.0.0"
+    "version": "2.1.0"
 }

--- a/test/carriers/amazon.js
+++ b/test/carriers/amazon.js
@@ -1,0 +1,205 @@
+const assert = require('assert');
+const Bloodhound = require('../../index');
+const Amazon = require('../../carriers/amazon');
+
+describe('Amazon', function() {
+    this.timeout(30000);
+
+    beforeEach(function(done) {
+        // Rate limiting to avoid overwhelming Amazon's API
+        setTimeout(() => {
+            done();
+        }, 2000);
+    });
+
+    const bloodhound = new Bloodhound();
+
+    describe('amazon.isTrackingNumberValid', function() {
+        const amazon = new Amazon();
+
+        const validTrackingNumbers = [
+            'TBA321677302718',
+            'TBA123456789012',
+            'TBM123456789012',
+            'TBC123456789012',
+            'TBA 3216 7730 2718',
+            'tba321677302718'
+        ];
+
+        const invalidTrackingNumbers = [
+            // Too short (12 chars total, only 9 after TBA)
+            'TBA123456789',
+            // Too long (>16 after TB)
+            'TBA123456789012345678901',
+            // Invalid second letter (not A, B, or C)
+            'TBD123456789012',
+            'TBE123456789012',
+            'TBZ123456789012',
+            // Mixed alphanumeric (not just digits after third letter)
+            'TBZ123A456B789C0',
+            'TBY12345ABCDE67',
+            // Wrong prefix
+            'XYZ123456789012',
+            // Wrong prefix (only one letter)
+            'T123456789012',
+            // UPS format
+            '1Z12345E0205271688',
+            // Random numbers
+            '1234567890',
+            // Empty string
+            '',
+            // Too short
+            'TBA',
+            // Wrong prefix (no T)
+            'AB123456789012',
+            // Wrong prefix
+            'A123456789012'
+        ];
+
+        it('should detect valid Amazon tracking numbers', function() {
+            validTrackingNumbers.forEach(trackingNumber => {
+                if (!amazon.isTrackingNumberValid(trackingNumber)) {
+                    assert.fail(`${trackingNumber} should be recognized as a valid Amazon tracking number`);
+                }
+            });
+        });
+
+        it('should not detect invalid Amazon tracking numbers', function() {
+            invalidTrackingNumbers.forEach(trackingNumber => {
+                if (amazon.isTrackingNumberValid(trackingNumber)) {
+                    assert.fail(`${trackingNumber} should not be recognized as a valid Amazon tracking number`);
+                }
+            });
+        });
+    });
+
+    describe('amazon.track', function() {
+        it('should return tracking information for a valid delivered package', function(done) {
+            bloodhound.track('TBA321677302718', 'amazon', function(err, actual) {
+                assert.ifError(err);
+
+                assert.strictEqual(actual.carrier, 'Amazon');
+                assert(actual.events.length > 0);
+                assert.strictEqual(typeof actual.url, 'string');
+                assert(actual.url.includes('TBA321677302718'));
+
+                // Check that we have meaningful events
+                const hasDeliveredEvent = actual.events.some(event =>
+                    event.description.toLowerCase().includes('delivered') ||
+                    event.description.toLowerCase().includes('package delivered')
+                );
+
+                if (actual.deliveredAt) {
+                    assert(hasDeliveredEvent, 'Should have delivered event when deliveredAt is set');
+                    assert(actual.deliveredAt instanceof Date);
+                }
+
+                if (actual.shippedAt) {
+                    assert(actual.shippedAt instanceof Date);
+                }
+
+                // Verify event structure
+                actual.events.forEach(event => {
+                    assert(Object.hasOwn(event, 'address'));
+                    assert(Object.hasOwn(event, 'date'));
+                    assert(Object.hasOwn(event, 'description'));
+                    assert(event.date instanceof Date);
+                    assert(typeof event.description === 'string');
+                    assert(event.description.length > 0);
+                });
+
+                done();
+            });
+        });
+
+        it('should handle tracking numbers with spaces', function(done) {
+            bloodhound.track('TBA 3216 7730 2718', 'amazon', function(err, actual) {
+                assert.ifError(err);
+                assert.strictEqual(actual.carrier, 'Amazon');
+                assert(actual.events.length > 0);
+                done();
+            });
+        });
+
+        it('should handle lowercase tracking numbers', function(done) {
+            bloodhound.track('tba321677302718', 'amazon', function(err, actual) {
+                assert.ifError(err);
+                assert.strictEqual(actual.carrier, 'Amazon');
+                assert(actual.events.length > 0);
+                done();
+            });
+        });
+
+        it('should return empty events for invalid tracking number', function(done) {
+            bloodhound.track('TBA000000000000', 'amazon', function(err, actual) {
+                // Should not return an error, but should have empty events (consistent with other carriers)
+                assert.ifError(err);
+                assert.strictEqual(actual.carrier, 'Amazon');
+                assert.strictEqual(actual.events.length, 0);
+                done();
+            });
+        });
+
+        it('should include location information when available', function(done) {
+            bloodhound.track('TBA321677302718', 'amazon', function(err, actual) {
+                assert.ifError(err);
+
+                // Look for events with location data
+                const eventsWithLocation = actual.events.filter(event =>
+                    event.address.city || event.address.state || event.address.country
+                );
+
+                if (eventsWithLocation.length > 0) {
+                    eventsWithLocation.forEach(event => {
+                        if (event.address.city) {
+                            assert(typeof event.address.city === 'string');
+                            assert(event.address.city.length > 0);
+                        }
+                        if (event.address.state) {
+                            assert(typeof event.address.state === 'string');
+                            assert(event.address.state.length > 0);
+                        }
+                        if (event.address.country) {
+                            assert(typeof event.address.country === 'string');
+                            assert(event.address.country.length > 0);
+                        }
+                    });
+                }
+
+                done();
+            });
+        });
+
+        it('should return raw data in results', function(done) {
+            bloodhound.track('TBA321677302718', 'amazon', function(err, actual) {
+                assert.ifError(err);
+                assert(Object.hasOwn(actual, 'raw'));
+
+                if (actual.raw) {
+                    assert(typeof actual.raw === 'object');
+                    // Should have expected Amazon API response structure
+                    assert(Object.hasOwn(actual.raw, 'eventHistory'));
+                    assert(Object.hasOwn(actual.raw, 'progressTracker'));
+                }
+
+                done();
+            });
+        });
+
+        it('should sort events chronologically', function(done) {
+            bloodhound.track('TBA321677302718', 'amazon', function(err, actual) {
+                assert.ifError(err);
+
+                if (actual.events.length > 1) {
+                    for (let i = 1; i < actual.events.length; i++) {
+                        const prevDate = new Date(actual.events[i - 1].date);
+                        const currDate = new Date(actual.events[i].date);
+                        assert(prevDate <= currDate, 'Events should be sorted chronologically (oldest first)');
+                    }
+                }
+
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Added Amazon carrier module with support for TBA/TBM/TBC tracking numbers  
- Implemented direct API integration with Amazon's tracking service
- Added comprehensive event code mapping for all shipping statuses including delivery attempts, exceptions, returns, and holds

## Test plan
- [x] All 9 Amazon carrier tests passing
- [x] Tracking number validation working for TBA/TBM/TBC formats
- [x] Live API integration tested with real tracking numbers
- [x] Error handling and edge cases covered
- [x] Integration with main Bloodhound module working
- [x] Documentation updated

🤖 Generated with [Claude Code](https://claude.ai/code)